### PR TITLE
Handle empty PayPal IPN custom data without logging error

### DIFF
--- a/plans_paypal/hooks.py
+++ b/plans_paypal/hooks.py
@@ -18,9 +18,11 @@ def parse_custom(custom):
 
 
 def get_custom_data(ipn_obj):
+    if not ipn_obj.custom or not ipn_obj.custom.strip():
+        return {"first_order_id": ipn_obj.item_number}
     try:
         return parse_custom(ipn_obj.custom)
-    except SyntaxError:
+    except (SyntaxError, ValueError):
         logger.exception(
             "Can't parse custom data",
             extra={

--- a/plans_paypal/tests/test_hooks.py
+++ b/plans_paypal/tests/test_hooks.py
@@ -7,7 +7,7 @@ from paypal.standard.models import ST_PP_COMPLETED
 from plans.base.models import AbstractRecurringUserPlan
 from plans.models import Invoice, Order
 
-from plans_paypal.hooks import parse_custom, receive_ipn
+from plans_paypal.hooks import get_custom_data, parse_custom, receive_ipn
 
 
 class HooksTests(TestCase):
@@ -15,6 +15,29 @@ class HooksTests(TestCase):
         ipn = baker.make("PayPalIPN")
         paypal_payment = receive_ipn(ipn)
         self.assertEqual(paypal_payment, None)
+
+    @patch("plans_paypal.hooks.logger")
+    def test_get_custom_data_empty_string_no_logging(self, mock_logger):
+        """Empty custom is a known PayPal pattern, should not log an error."""
+        ipn = baker.make("PayPalIPN", custom="", item_number="12345")
+        result = get_custom_data(ipn)
+        self.assertEqual(result, {"first_order_id": "12345"})
+        mock_logger.exception.assert_not_called()
+
+    @patch("plans_paypal.hooks.logger")
+    def test_get_custom_data_whitespace_no_logging(self, mock_logger):
+        ipn = baker.make("PayPalIPN", custom="  ", item_number="67890")
+        result = get_custom_data(ipn)
+        self.assertEqual(result, {"first_order_id": "67890"})
+        mock_logger.exception.assert_not_called()
+
+    @patch("plans_paypal.hooks.logger")
+    def test_get_custom_data_garbage_still_logs(self, mock_logger):
+        """Non-empty unparseable custom data should still log for investigation."""
+        ipn = baker.make("PayPalIPN", custom="not-valid-python", item_number="99999")
+        result = get_custom_data(ipn)
+        self.assertEqual(result, {"first_order_id": "99999"})
+        mock_logger.exception.assert_called_once()
 
     def test_parse_custom(self):
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Handles empty/whitespace `custom` field in PayPal IPN without logging an error
- Catches `ValueError` alongside `SyntaxError` for future Python version safety

## Why

PayPal sends IPNs with empty `custom` field for certain recurring subscriptions. `ast.literal_eval("")` raises `SyntaxError`, which is caught but logged via `logger.exception()` — generating **4,074 Sentry events** (Sentry: QBX) for a known, non-exceptional condition.

## Changes

| File | Change |
|------|--------|
| `plans_paypal/hooks.py` | Early return for empty `custom`, catch `ValueError` too |
| `plans_paypal/tests/test_hooks.py` | 3 new tests: empty string (no logging), whitespace (no logging), garbage (still logs) |

## Test plan

- [x] All 12 tests pass (3 new + 9 existing)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only affects `custom` parsing/logging in the PayPal IPN hook and adds tests; payment flow behavior remains the same via the existing `first_order_id` fallback.
> 
> **Overview**
> Prevents `plans_paypal` from logging exceptions when PayPal IPNs arrive with an empty or whitespace-only `custom` field by short-circuiting to the existing `{"first_order_id": item_number}` fallback.
> 
> Expands error handling for malformed `custom` values to also catch `ValueError`, and adds focused tests to ensure empty/whitespace inputs do **not** log while non-empty garbage still does.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e250e0b5be7f7a979c4a7b5e1efb6b13387ad37d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->