### PR TITLE
PaymentFailureView: redirect completed orders to success, not 500

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,16 @@
 History
 -------
 
+unreleased
+++++++++++
+
+* ``PaymentFailureView``: redirect already-completed orders to the success
+  page (with a warning log) instead of raising ``ValueError``. PayPal can
+  send the buyer to the ``cancel_return`` URL even after the IPN has
+  marked the order as completed (browser back button, stale tabs, edge
+  cases in the PayPal flow); the previous behaviour produced unhandled
+  500s for paid users. Reverses the 0.7.1 behaviour change.
+
 1.1.0 (2025-06-20)
 ++++++++++++++++++
 

--- a/plans_paypal/tests/test_views.py
+++ b/plans_paypal/tests/test_views.py
@@ -28,12 +28,30 @@ class PaymentFailureViewTests(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_payment_failure_view_order_completed(self):
+        """Already-completed orders redirect to success, not failure.
+
+        PayPal can send the buyer to ``cancel_return`` even after the IPN has
+        marked the order as completed (browser back button, stale tabs, or
+        edge cases in the PayPal flow). The view must not 500 in that case
+        and must not flip a paid order to ``CANCELED``.
+        """
         order = baker.make(Order, status=Order.STATUS.COMPLETED)
         self.client.force_login(order.user)
-        with self.assertRaisesRegex(ValueError, r"^Invalid order status: 2"):
-            self.client.get(reverse("paypal-payment-failure", args=[order.id]))
+        with self.assertLogs("plans_paypal.views", level="WARNING") as cm:
+            response = self.client.get(
+                reverse("paypal-payment-failure", args=[order.id])
+            )
+        self.assertRedirects(
+            response,
+            reverse("order_payment_success", args=[order.id]),
+            target_status_code=302,
+        )
         order.refresh_from_db()
         self.assertEqual(order.status, Order.STATUS.COMPLETED)
+        self.assertTrue(
+            any("already-completed order" in m for m in cm.output),
+            cm.output,
+        )
 
     def test_payment_failure_view_not_logged_in(self):
         order = baker.make(Order, user=baker.make("User"))

--- a/plans_paypal/views.py
+++ b/plans_paypal/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -7,6 +8,8 @@ from django.urls import reverse
 from django.views.generic import View
 from paypal.standard.forms import PayPalEncryptedPaymentsForm, PayPalPaymentsForm
 from plans.models import Order
+
+logger = logging.getLogger(__name__)
 
 
 class PlansPayPalPaymentsFormMixin:
@@ -115,9 +118,18 @@ def view_that_asks_for_money(request, order_id, sandbox=False):
 class PaymentFailureView(LoginRequiredMixin, View):
     def get(self, request, *args, order_id=None, payment_variant=None):
         order = get_object_or_404(Order, pk=order_id, user=request.user)
-        # This view is meant to cancel the order before it is completed.
+        # This view is the PayPal ``cancel_return`` landing page. A completed
+        # order means the IPN already confirmed payment before the user reached
+        # us (browser back button, stale tab refresh, or PayPal sending the
+        # buyer here after a successful payment). Cancelling a paid order would
+        # be wrong, so send the user to the success page instead.
         if order.status == Order.STATUS.COMPLETED:
-            raise ValueError(f"Invalid order status: {order.status}")
+            logger.warning(
+                "PaymentFailureView reached for already-completed order %s; "
+                "redirecting to success page.",
+                order.pk,
+            )
+            return redirect(reverse("order_payment_success", kwargs={"pk": order_id}))
         order.status = Order.STATUS.CANCELED
         # In case django-simple-history is installed
         order._change_reason = "Django-payments-paypal: Payment failed by cancel view"


### PR DESCRIPTION
PayPal can route the buyer to the cancel_return URL even after the IPN has already marked the order as COMPLETED (browser back button, stale tabs, edge cases in the PayPal flow). The previous behaviour - raising ValueError on a completed order - produced unhandled 500s on Sentry for users who had successfully paid.

Redirect to the success page (with a warning log) instead. The order is genuinely paid, so the success page is the correct landing; cancelling the order would be wrong, but failing with 500 is too. Reverses the 0.7.1 behaviour change.

Test inverted to assert the new redirect + log + preserved COMPLETED status. HISTORY.rst entry added under unreleased.