### PR TITLE
black: drop isort lines_after_imports override and reformat

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@
 import os
 import sys
 
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -25,7 +24,6 @@ parent = os.path.dirname(cwd)
 sys.path.append(parent)
 
 import plans_paypal
-
 
 # -- General configuration -----------------------------------------------------
 

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 
-
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
     from django.core.management import execute_from_command_line

--- a/plans_paypal/hooks.py
+++ b/plans_paypal/hooks.py
@@ -9,7 +9,6 @@ from plans.models import Order, Plan, Pricing
 
 from .models import PayPalPayment
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/plans_paypal/urls.py
+++ b/plans_paypal/urls.py
@@ -2,7 +2,6 @@ from django.urls import include, path
 
 from . import views
 
-
 urlpatterns = [
     path(
         "paypal-payment/<int:order_id>/",

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,5 +24,4 @@ import-order-style = pep8
 
 [isort]
 multi_line_output = 3
-lines_after_imports = 2
 profile = black

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import sys
 
 from setuptools import find_packages
 
-
 try:
     from setuptools import setup
 except ImportError:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8
 from __future__ import absolute_import, unicode_literals
 
-
 DEBUG = True
 USE_TZ = True
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 
 from django.urls import include, path
 
-
 urlpatterns = [
     path("", include("plans_paypal.urls")),
     path("plans", include("plans.urls")),


### PR DESCRIPTION
isort had ``lines_after_imports = 2`` while also requesting ``profile = black``. The two disagree on the blank-line count between imports and a top-level non-class/def statement (logger assignment, WSGI ``if __name__``, Sphinx config, etc.): isort wanted 2, black wants 1. The result was a CI lint job that has been red for a while, because every file with that pattern fails ``black --check``.

Drop the explicit override (``profile = black`` already sets the right defaults) and run ``black .`` to fix the 7 affected files. No logic changes, only blank-line removals.